### PR TITLE
include math.h, fix extra qualification error

### DIFF
--- a/StepKernel.cpp
+++ b/StepKernel.cpp
@@ -98,7 +98,7 @@ void StepKernel::build_tri_body(std::vector<double> tris,double tol, int &merged
 		d1[1] = d1[1] / dist1;
 		d1[2] = d1[2] / dist1;
 
-		// now cross 
+		// now cross
 		// cross to get the thrid direction for the beam csys
 		double d2[3] = { d0[1] * d1[2] - d0[2] * d1[1], d0[2] * d1[0] - d0[0] * d1[2], d0[0] * d1[1] - d0[1] * d1[0] };
 		double dist2 = sqrt(d2[0] * d2[0] + d2[1] * d2[1] + d2[2] * d2[2]);
@@ -172,7 +172,7 @@ void StepKernel::get_edge_from_map(
 	double  p0[3],
 	double  p1[3],
 	std::map<std::tuple<double, double, double, double, double, double>, StepKernel::EdgeCurve *> &edge_map,
-	StepKernel::Vertex * vert1, 
+	StepKernel::Vertex * vert1,
 	StepKernel::Vertex * vert2,
 	EdgeCurve *& edge_curve,
 	bool &edge_dir,
@@ -295,7 +295,7 @@ void StepKernel::read_step(std::string file_name)
 			auto id_str = cur_str.substr(1, equal_pos - 1);
 			id = std::atoi(id_str.c_str());
 			auto func_start = cur_str.find_first_not_of("\t ", equal_pos+1);
-			auto func_end = cur_str.find_first_of('\t (', equal_pos + 1);
+			auto func_end = cur_str.find_first_of("\t (", equal_pos + 1);
 			auto func_name = cur_str.substr(func_start, func_end - func_start);
 
 			// now parse the args

--- a/StepKernel.h
+++ b/StepKernel.h
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include <map>
 #include <algorithm>
 #include <sstream>
+#include <math.h>
 
 class StepKernel
 {
@@ -55,7 +56,7 @@ public:
 			// Find first non-delimiter.
 			std::string::size_type pos = str.find_first_of(delimiters, lastPos);
 
-			while (std::string::npos != pos || std::string::npos != lastPos) 
+			while (std::string::npos != pos || std::string::npos != lastPos)
 			{
 				// Found a token, add it to the vector.
 				tokens.push_back(str.substr(lastPos, pos - lastPos));
@@ -755,7 +756,7 @@ public:
 		bool &edge_dir,
 		int &merge_cnt);
 	void write_step(std::string file_name);
-	std::string StepKernel::read_line(std::ifstream &stp_file, bool skip_all_space);
+	std::string read_line(std::ifstream &stp_file, bool skip_all_space);
 	void read_step(std::string file_name);
 	std::vector<Entity*> entities;
 };


### PR DESCRIPTION
using GCC 8.3.0 on Arch I got those errors that I fixed:

In file included from /home/jglauche/src/stltostp/StepKernel.cpp:29:
/home/jglauche/src/stltostp/StepKernel.h:758:14: error: extra qualification 'StepKernel::' on member 'read_line' [-fpermissive]
  std::string StepKernel::read_line(std::ifstream &stp_file, bool skip_all_space);
              ^~~~~~~~~~
/home/jglauche/src/stltostp/StepKernel.cpp: In member function 'StepKernel::EdgeCurve* StepKernel::create_edge_curve(StepKernel::Vertex*, StepKernel::Vertex*, bool)':
/home/jglauche/src/stltostp/StepKernel.cpp:52:16: error: 'sqrt' was not declared in this scope
  double dist = sqrt(vx * vx + vy * vy + vz * vz);
                ^~~~