### PR TITLE
Switch Windows installer from WiX to NSIS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ ADD_TEST(
 INSTALL(TARGETS ${PROJECT_NAME} DESTINATION "bin/")
 
 if(WIN32)
-set(CPACK_GENERATOR WIX)
+set(CPACK_GENERATOR NSIS)
 set(CPACK_PACKAGE_NAME "stltostp")
 set(CPACK_PACKAGE_VENDOR "slugdev")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
@@ -57,8 +57,17 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Command line utility to convert stl files
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "0")
 set(CPACK_PACKAGE_VERSION_PATCH "2")
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CMAKE_PROJECT_NAME}/${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
-set(CPACK_WIX_UPGRADE_GUID "F9AEABA2-D7AF-4EA6-BF46-B3E165410D17")
+# no path separator here: the NSIS generator requires escaped backslashes in
+# nested install directories, so use a flat "name version" folder instead
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CMAKE_PROJECT_NAME} ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
+set(CPACK_NSIS_DISPLAY_NAME "stltostp")
+set(CPACK_NSIS_PACKAGE_NAME "stltostp")
+set(CPACK_NSIS_URL_INFO_ABOUT "https://github.com/slugdev/stltostp")
+# remove any previous version first so upgrades stay clean (replaces the
+# WiX upgrade GUID behaviour)
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+# stltostp is a command line tool: offer adding the install dir to PATH
+set(CPACK_NSIS_MODIFY_PATH ON)
 include (InstallRequiredSystemLibraries)
 include(CPack)
 endif(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,27 +49,26 @@ ADD_TEST(
 INSTALL(TARGETS ${PROJECT_NAME} DESTINATION "bin/")
 
 if(WIN32)
-set(CPACK_GENERATOR NSIS)
-set(CPACK_PACKAGE_NAME "stltostp")
-set(CPACK_PACKAGE_VENDOR "slugdev")
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Command line utility to convert stl files to STEP brep files.")
-set(CPACK_PACKAGE_VERSION_MAJOR "1")
-set(CPACK_PACKAGE_VERSION_MINOR "0")
-set(CPACK_PACKAGE_VERSION_PATCH "2")
-# no path separator here: the NSIS generator requires escaped backslashes in
-# nested install directories, so use a flat "name version" folder instead
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CMAKE_PROJECT_NAME} ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
-set(CPACK_NSIS_DISPLAY_NAME "stltostp")
-set(CPACK_NSIS_PACKAGE_NAME "stltostp")
-set(CPACK_NSIS_URL_INFO_ABOUT "https://github.com/slugdev/stltostp")
-# remove any previous version first so upgrades stay clean (replaces the
-# WiX upgrade GUID behaviour)
-set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
-# stltostp is a command line tool: offer adding the install dir to PATH
-set(CPACK_NSIS_MODIFY_PATH ON)
-include (InstallRequiredSystemLibraries)
-include(CPack)
+  set(CPACK_GENERATOR NSIS)
+  set(CPACK_PACKAGE_NAME "stltostp")
+  set(CPACK_PACKAGE_VENDOR "slugdev")
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Command line utility to convert stl files to STEP brep files.")
+  set(CPACK_PACKAGE_VERSION_MAJOR "1")
+  set(CPACK_PACKAGE_VERSION_MINOR "0")
+  set(CPACK_PACKAGE_VERSION_PATCH "2")
+  # no path separator here: the NSIS generator requires escaped backslashes in
+  # nested install directories, so use a flat "name version" folder instead
+  set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CMAKE_PROJECT_NAME} ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
+  set(CPACK_NSIS_DISPLAY_NAME "stltostp")
+  set(CPACK_NSIS_PACKAGE_NAME "stltostp")
+  set(CPACK_NSIS_URL_INFO_ABOUT "https://github.com/slugdev/stltostp")
+  # remove any previous NSIS-based version first so upgrades between NSIS
+  # installers stay clean
+  set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+  # stltostp is a command line tool: offer adding the install dir to PATH
+  set(CPACK_NSIS_MODIFY_PATH ON)
+  include(InstallRequiredSystemLibraries)
+  include(CPack)
 endif(WIN32)
-
 


### PR DESCRIPTION
- CPACK_GENERATOR WIX -> NSIS; drop the WiX upgrade GUID and use CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL for clean upgrades instead
- Flatten CPACK_PACKAGE_INSTALL_DIRECTORY to 'stltostp 1.0' since the NSIS generator cannot handle forward slashes in nested install dirs
- Enable CPACK_NSIS_MODIFY_PATH so users can add the CLI to PATH from the installer; link project URL in Add/Remove Programs

Verified with NSIS 3.12: cpack produces build/stltostp-1.0.2-win64.exe and all ctest suites still pass.